### PR TITLE
feat: add playground to GitHub Workflow

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,0 +1,34 @@
+name: Example
+
+on:
+  workflow_dispatch:
+    inputs:
+      FORMAT:
+        description: Format
+        required: true
+        default: table
+
+jobs:
+  playground:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Deploy server
+        working-directory: ./node-todo/
+        run: docker-compose up -d
+
+      - name: Create random todo
+        run: docker-compose run todo playground add
+
+      - name: List todo
+        run: docker-compose run todo list --output ${{ github.event.inputs.FORMAT }}
+
+      - name: Delete todo
+        run: docker-compose run todo playground delete
+
+      - name: List todo
+        run: docker-compose run todo list --output ${{ github.event.inputs.FORMAT }}

--- a/scripts/commands/playground/__init__.py
+++ b/scripts/commands/playground/__init__.py
@@ -1,0 +1,3 @@
+"""This package implements the commands to deploy the playground."""
+from .cli import *
+from .task import *

--- a/scripts/commands/playground/cli.py
+++ b/scripts/commands/playground/cli.py
@@ -1,0 +1,35 @@
+"""This module implements the commands to deploy the playground."""
+import logging
+import click
+from click import ClickException
+
+from .task import GenerateRandom, DeleteAll
+from scripts.utils.errors import TaskError
+
+
+logger = logging.getLogger(__name__)
+
+
+@click.group()
+def playground():
+    """Parent command for playground operations."""
+
+
+@playground.command(name='add')
+def generate_random():
+    """Create a random number of todo items between 10 and 100."""
+    try:
+        GenerateRandom().run()
+    except TaskError as e:
+        logger.error(f"{e.error_msg}. Additional info: {e.additional_info}")
+        raise ClickException(f"An error occurred while creating a new event. Additional info: {e.error_msg}") from e
+
+
+@playground.command(name='delete')
+def delete_all():
+    """Delete all the todo items."""
+    try:
+        DeleteAll().run()
+    except TaskError as e:
+        logger.error(f"{e.error_msg}. Additional info: {e.additional_info}")
+        raise ClickException(f"An error occurred while deleting all the events. Additional info: {e.error_msg}") from e

--- a/scripts/commands/playground/cli.py
+++ b/scripts/commands/playground/cli.py
@@ -3,8 +3,8 @@ import logging
 import click
 from click import ClickException
 
-from .task import GenerateRandom, DeleteAll
 from scripts.utils.errors import TaskError
+from .task import DeleteAll, GenerateRandom
 
 
 logger = logging.getLogger(__name__)

--- a/scripts/commands/playground/task.py
+++ b/scripts/commands/playground/task.py
@@ -1,0 +1,35 @@
+"""This module implements the tasks related to deploy the playground."""
+from faker import Faker
+import random
+
+from scripts.commands.add.task import Add
+from scripts.commands.delete.task import Delete
+from scripts.utils.constants import API_URL
+from scripts.utils.request import Request
+
+
+class GenerateRandom():
+    """Task to create a random number of todo items between 10 and 100."""
+    def __init__(self):
+        pass
+
+    def run(self):
+        """Run the task."""
+        fake = Faker('es_ES')
+        names = [fake.name() for _ in range(random.randint(10, 100))]
+
+        for name in names:
+            Add(name).run()
+
+
+class DeleteAll():
+    """Task to delete all the todo items."""
+    def __init__(self):
+        pass
+
+    def run(self):
+        """Run the task."""
+        list_items = Request(API_URL, timeout=2.5).get()
+
+        for item in list_items:
+            Delete(item['text']).run()

--- a/scripts/commands/playground/task.py
+++ b/scripts/commands/playground/task.py
@@ -1,6 +1,6 @@
 """This module implements the tasks related to deploy the playground."""
-from faker import Faker
 import random
+from faker import Faker
 
 from scripts.commands.add.task import Add
 from scripts.commands.delete.task import Delete

--- a/todo
+++ b/todo
@@ -6,6 +6,7 @@ import click
 from scripts.commands.list import get_list
 from scripts.commands.add import add_event
 from scripts.commands.delete import delete_event
+from scripts.commands.playground import playground
 from scripts.utils.constants import PATH
 
 
@@ -39,6 +40,7 @@ def main():
 main.add_command(get_list)
 main.add_command(add_event)
 main.add_command(delete_event)
+main.add_command(playground)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# PR Summary

An iteractive workflow has been created in order to test the program.

## Detailed Description

In this PR we have created a GitHub workflow playground to test the `add`, `list` and `delete` commands:
- It creates from 10 to 100 random items.
- Display this items. Choice between `json`, `txt` and `table`.
- Delete all items in the list

## Related Issues

Not applicable.

## How Has This Been Tested

| Test performed | Expected behavior | Status |
|---|---|:---:|
| Run this workflow with output `json` | It works correctly | ✅ |
| Run this workflow with output `txt` | It works correctly | ✅ |
| Run this workflow with output `table` | It works correctly | ✅ |